### PR TITLE
Fix #2 and #3; improve debugging a bit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ were never merged.
        --gitlab-url http://workbench.dachary.org \
        --gitlab-token sxQJ67SQKihMrGWVf \
        --gitlab-repo ceph/ceph-backports \
-       --github-token 64933d355fda9844aadd4e224d \
+       --github-auth githubusername:64933d355fda9844aadd4e224d \
        --github-repo ceph/ceph \
        --ignore-closed
 
@@ -90,7 +90,7 @@ Hacking
     --gitlab-url http://workbench.dachary.org \
     --gitlab-token XXXXXXXXX \
     --gitlab-repo dachary/testrepo2 \
-    --github-token XXXXXXXXX \
+    --github-auth XXXXXXXXX \
     --github-repo dachary/testrepo \
     --ssh-public-key ~/.ssh/id_rsa.pub \
     --verbose  

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -69,7 +69,7 @@ class GitHub2GitLab(object):
             'url': "https://api.github.com",
             'git': "https://github.com",
             'repo': self.args.github_repo,
-            'token': self.args.github_token,
+            'auth': self.args.github_auth or None
         }
         if self.args.branches:
             self.github['branches'] = self.args.branches.split(',')
@@ -116,8 +116,8 @@ class GitHub2GitLab(object):
                             required=True)
         parser.add_argument('--gitlab-repo',
                             help='Gitlab repo (for instance ceph/ceph)')
-        parser.add_argument('--github-token',
-                            help='GitHub authentication token')
+        parser.add_argument('--github-auth',
+                            help='GitHub auth credentials, in the form username:token')
         parser.add_argument('--github-repo',
                             help='GitHub repo (for instance ceph/ceph)',
                             required=True)
@@ -197,9 +197,15 @@ class GitHub2GitLab(object):
 
     def git_mirror(self):
         name = self.gitlab['name']
+        url = self.github['git']
+
+        if(self.github['auth']):
+            url = self.github['git'].replace('https://', 'https://{}@'.format(self.github['auth']))
+
         if not os.path.exists(name):
-            self.sh("git clone --bare " + self.github['git'] +
+            self.sh("git clone --bare " + url +
                     "/" + self.github['repo'] + " " + name)
+
         repo = git.Repo(name)
         os.chdir(name)
         if not hasattr(repo.remotes, 'gitlab'):
@@ -508,8 +514,8 @@ class GitHub2GitLab(object):
         "https://developer.github.com/v3/pulls/#list-pull-requests"
         g = self.github
         query = {'state': 'all'}
-        if self.args.github_token:
-            query['access_token'] = g['token']
+        if g['auth']:
+            query['access_token'] = g['auth'].split(':')[1]
 
         def f(pull):
             if self.args.ignore_closed:

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -540,7 +540,7 @@ class GitHub2GitLab(object):
         g = self.gitlab
         query['private_token'] = g['token']
         url = g['url'] + "/projects/" + g['repo'] + "/merge_requests"
-        log.info('create_merge_request: ' + str(query))
+        log.debug('create_merge_request: ' + str(query))
         result = requests.post(url, params=query)
         if result.status_code != requests.codes.created:
             raise ValueError(result.text)
@@ -576,7 +576,7 @@ class GitHub2GitLab(object):
         updates['private_token'] = g['token']
         url = (g['url'] + "/projects/" + g['repo'] + "/merge_requests/" +
                str(merge_request['iid']))
-        log.info('update_merge_request: ' + url + ' <= ' + str(updates))
+        log.debug('update_merge_request: ' + url + ' <= ' + str(updates))
         return requests.put(url, params=updates).json()
 
     def verify_merge_update(self, updates, result):

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -130,6 +130,9 @@ class GitHub2GitLab(object):
         parser.add_argument('--ignore-closed', action='store_const',
                             const=True,
                             help='ignore pull requests closed and not merged')
+        parser.add_argument('--skip-add-key', action='store_const',
+                            const=True,
+                            help='do not attempt to add local SSH key to Gitlab')
         parser.add_argument('--skip-pull-requests', action='store_const',
                             const=True,
                             help='do not mirror PR to MR')
@@ -152,7 +155,8 @@ class GitHub2GitLab(object):
         return GitHub2GitLab(GitHub2GitLab.get_parser().parse_args(argv))
 
     def run(self):
-        self.add_key()
+        if not self.args.skip_add_key:
+            self.add_key()
         if self.add_project():
             self.unprotect_branches()
         self.git_mirror()

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -78,7 +78,7 @@ class GitHub2GitLab(object):
             'host': self.args.gitlab_url,
             'name': self.args.gitlab_name,
             'namespace': self.args.gitlab_namespace,
-            'group': None,
+            'group_id': None,
             'url': self.args.gitlab_url + "/api/v4",
             'repo': self.args.gitlab_repo,
             'token': self.args.gitlab_token,

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -21,6 +21,7 @@ import argparse
 import git
 import gitdb
 import hashlib
+from http.client import HTTPConnection
 import json
 import logging
 import os
@@ -81,9 +82,11 @@ class GitHub2GitLab(object):
 
         if self.args.verbose:
             level = logging.DEBUG
+            HTTPConnection.debuglevel = 1
         else:
             level = logging.INFO
 
+        logging.getLogger("urllib3").setLevel(level)
         logging.getLogger('github2gitlab').setLevel(level)
 
         self.tmpdir = "/tmp"

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -243,7 +243,7 @@ class GitHub2GitLab(object):
     def git_mirror_optimize(self, repo):
         self.sh("git fetch origin +refs/pull/*:refs/remotes/origin/pull/*")
         for head in repo.refs:
-            pr = re.search('^origin/pull/(\d+)/head$', head.name)
+            pr = re.search('^origin/pull/(\\d+)/head$', head.name)
             if not pr:
                 continue
             pr = pr.group(1)

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -183,9 +183,12 @@ class GitHub2GitLab(object):
                 lines.append(line)
                 log.debug(str(line.strip()))
         if proc.wait() != 0:
+            output = "".join(lines)
+            log.error("Command failed: " + command + "\n" + output)
             raise subprocess.CalledProcessError(
                 returncode=proc.returncode,
-                cmd=command
+                cmd=command,
+                output=output
             )
         return "".join(lines)
 

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -34,6 +34,7 @@ import time
 import shutil
 
 DESCRIPTION_MAX = 1024
+TITLE_MAX = 255
 
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s')
 
@@ -380,6 +381,13 @@ class GitHub2GitLab(object):
             merge_value = merge_value.replace(GitHub2GitLab.TAG_MERGED, '')
             return (pull_value[:DESCRIPTION_MAX] ==
                     merge_value[:DESCRIPTION_MAX])
+        elif pull_field == 'title':
+            if merge_value is None:
+                merge_value = ''
+            if pull_value is None:
+                pull_value = ''
+            return (pull_value[:TITLE_MAX] ==
+                    merge_value[:TITLE_MAX])
         else:
             return pull_value == merge_value
 
@@ -399,6 +407,8 @@ class GitHub2GitLab(object):
             return ('state_event', value)
         elif pull_field == 'body':
             return (merge_field, pull_value[:DESCRIPTION_MAX])
+        elif pull_field == 'title':
+            return (merge_field, pull_value[:TITLE_MAX])
         else:
             return (merge_field, pull_value)
 
@@ -418,7 +428,7 @@ class GitHub2GitLab(object):
                 target_branch = pull['base']['ref']
                 if (self.rev_parse(pull, source_branch) and
                         self.rev_parse(pull, target_branch)):
-                    data = {'title': pull['title'],
+                    data = {'title': pull['title'][:TITLE_MAX],
                             'source_branch': source_branch,
                             'target_branch': target_branch}
                     if pull['body']:

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -171,8 +171,7 @@ class GitHub2GitLab(object):
             args=command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
-            bufsize=1)
+            shell=True)
         lines = []
         with proc.stdout:
             for line in iter(proc.stdout.readline, b''):

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -96,7 +96,7 @@ class GitHub2GitLab(object):
 
         g = self.gitlab
         url = g['url'] + "/groups"
-        query = {'private_token': g['token'], 'all_available': 'true', 'per_page': 10000}
+        query = {'private_token': g['token'], 'all_available': 'true', 'per_page': 100, 'search': g['namespace'].split('/')[-1]}
         groups = requests.get(url, params=query).json()
         matches = list(filter(lambda group: group['full_path'] == g['namespace'].lower(), groups))
         if any(matches):

--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -58,8 +58,11 @@ class GitHub2GitLab(object):
 
         if not self.args.gitlab_repo:
             self.args.gitlab_repo = self.args.github_repo
-        (self.args.gitlab_namespace,
-         self.args.gitlab_name) = self.args.gitlab_repo.split('/')
+
+        repo_parts = self.args.gitlab_repo.split('/')
+        self.args.gitlab_name = repo_parts.pop()
+        self.args.gitlab_namespace = '/'.join(repo_parts)
+
         self.args.gitlab_repo = parse.quote_plus(self.args.gitlab_repo)
 
         self.github = {
@@ -75,6 +78,7 @@ class GitHub2GitLab(object):
             'host': self.args.gitlab_url,
             'name': self.args.gitlab_name,
             'namespace': self.args.gitlab_namespace,
+            'group': None,
             'url': self.args.gitlab_url + "/api/v4",
             'repo': self.args.gitlab_repo,
             'token': self.args.gitlab_token,
@@ -88,6 +92,14 @@ class GitHub2GitLab(object):
 
         logging.getLogger("urllib3").setLevel(level)
         logging.getLogger('github2gitlab').setLevel(level)
+
+        g = self.gitlab
+        url = g['url'] + "/groups"
+        query = {'private_token': g['token'], 'all_available': 'true', 'per_page': 10000}
+        groups = requests.get(url, params=query).json()
+        matches = list(filter(lambda group: group['full_path'] == g['namespace'].lower(), groups))
+        if any(matches):
+            g['group_id'] = matches[0]['id']
 
         self.tmpdir = "/tmp"
 
@@ -130,6 +142,9 @@ class GitHub2GitLab(object):
         parser.add_argument('--clean', action='store_const',
                             const=True,
                             help='Remove the repo after sync')
+        parser.add_argument('--visibility',
+                            help='Visbility of created repos (public, internal, private)',
+                            default='public')
         return parser
 
     @staticmethod
@@ -288,15 +303,21 @@ class GitHub2GitLab(object):
         g = self.gitlab
         url = g['url'] + "/projects/" + g['repo']
         query = {'private_token': g['token']}
+        if g['group_id']:
+            query['group_id'] = g['group_id']
+
         if (requests.get(url, params=query).status_code == requests.codes.ok):
             log.debug("project " + url + " already exists")
             return None
         else:
-            log.info("add project " + g['repo'])
             url = g['url'] + "/projects"
-            query['public'] = 'true'
-            query['namespace'] = g['namespace']
+            query['visibility'] = self.args.visibility
             query['name'] = g['name']
+            if g['group_id']:
+                query['namespace_id'] = g['group_id']
+            else:
+                query['namespace'] = g['namespace']
+            log.info("add project " + g['repo'])
             result = requests.post(url, params=query)
             if result.status_code != requests.codes.created:
                 raise ValueError(result.text)


### PR DESCRIPTION
This was a small basket of fixes I needed to make to enable migration in an enterprise scenario:

- I don't have (local CLI) Github login auth for the repos being transferred; I only have a token
- I am moving repos into a nested project structure in Gitlab. The code previously expected a flat namespace name with no `/`
- I want to be able to specify the visibility of the newly-created project in Gitlab
- I needed better debugging help to see what was going wrong during my debugging
- Various other bug fixes that arose from running the code under a more recent Python 3.x version